### PR TITLE
feat: refactor into modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "lib",
     "!lib/test"
   ],
+  "bin": {
+    "module-replacements": "./lib/bin.js",
+    "mr": "./lib/bin.js"
+  },
   "scripts": {
     "clean:build": "premove lib",
     "clean:test": "premove coverage",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import {run} from './main.js';
+
+run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,320 +1,19 @@
 import * as cl from '@clack/prompts';
 import * as modReplacements from 'module-replacements';
-import {exit, cwd} from 'node:process';
+import {exit, cwd as getCwd} from 'node:process';
 import {findPackage} from 'fd-package-json';
 import dedent from 'dedent';
-import pc from 'picocolors';
-import {fdir} from 'fdir';
-import {getDocsUrl, getMdnUrl} from './replacement-urls.js';
-import {ts as sg} from '@ast-grep/napi';
-import {readFile, writeFile} from 'node:fs/promises';
-import {extname} from 'node:path';
-import {codemods, type Codemod} from 'module-replacements-codemods';
 import {x} from 'tinyexec';
+import {scanFiles} from './stages/scan-files.js';
+import {fixFiles} from './stages/fix-files.js';
+import {traverseFiles} from './stages/traverse-files.js';
+import {scanDependencies} from './stages/scan-dependencies.js';
 
 const availableManifests: Record<string, modReplacements.ManifestModule> = {
   native: modReplacements.nativeReplacements,
   'micro-utilities': modReplacements.microUtilsReplacements,
   preferred: modReplacements.preferredReplacements
 };
-
-const packageManifest = await findPackage(cwd());
-
-interface PackageSource {
-  type: 'package';
-  source: 'dependencies' | 'devDependencies';
-}
-interface FileSource {
-  type: 'file';
-  path: string;
-  line: number;
-  column: number;
-  snippet: string;
-}
-type Source = PackageSource | FileSource;
-
-function renderSource(source: Source): string {
-  switch (source.type) {
-    case 'package':
-      return dedent`
-        ${pc.bold('package.json')}
-      `;
-    case 'file':
-      return dedent`
-        ${pc.bold(`${source.path} (${source.line}:${source.column})`)}
-
-        ${source.snippet}
-      `;
-  }
-}
-
-function suggestDocumentedReplacement(
-  replacement: modReplacements.DocumentedModuleReplacement,
-  source: Source
-): void {
-  cl.log.warn(dedent`
-    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
-
-    Module ${pc.cyan(replacement.moduleName)} could be replaced with a more performant alternative.
-
-    You can find an alternative in the following documentation:
-    ${pc.underline(getDocsUrl(replacement.docPath))}
-  `);
-}
-
-function suggestNativeReplacement(
-  replacement: modReplacements.NativeModuleReplacement,
-  source: Source
-): void {
-  cl.log.warn(dedent`
-    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
-
-    Module ${pc.cyan(replacement.moduleName)} could be replaced with the following native functionality:
-
-    ${pc.underline(getMdnUrl(replacement.mdnPath))}
-  `);
-}
-
-function suggestNoneReplacement(
-  replacement: modReplacements.NoModuleReplacement,
-  source: Source
-): void {
-  cl.log.warn(dedent`
-    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
-
-    Module ${pc.cyan(replacement.moduleName)} could be removed or replaced with a more performant alternative.
-  `);
-}
-
-function suggestSimpleReplacement(
-  replacement: modReplacements.SimpleModuleReplacement,
-  source: Source
-): void {
-  cl.log.warn(dedent`
-    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
-
-    Module ${pc.cyan(replacement.moduleName)} could be replaced inline/native equivalent logic.
-
-    ${replacement.replacement}
-  `);
-}
-
-function suggestReplacement(
-  replacement: modReplacements.ModuleReplacement,
-  source: Source
-): void {
-  switch (replacement.type) {
-    case 'documented':
-      return suggestDocumentedReplacement(replacement, source);
-    case 'native':
-      return suggestNativeReplacement(replacement, source);
-    case 'none':
-      return suggestNoneReplacement(replacement, source);
-    case 'simple':
-      return suggestSimpleReplacement(replacement, source);
-  }
-}
-
-interface DependencyResult {
-  match: modReplacements.ModuleReplacement;
-  source: PackageSource['source'];
-}
-
-function traverseDependencies(
-  dependencies: Record<string, string>,
-  replacements: modReplacements.ModuleReplacement[],
-  source: PackageSource['source']
-): DependencyResult[] {
-  const results: DependencyResult[] = [];
-
-  for (const key in dependencies) {
-    for (const replacement of replacements) {
-      if (key === replacement.moduleName) {
-        results.push({
-          match: replacement,
-          source
-        });
-        suggestReplacement(replacement, {type: 'package', source});
-      }
-    }
-  }
-
-  return results;
-}
-
-interface ScanFileResult {
-  path: string;
-  contents: string;
-  matches: modReplacements.ModuleReplacement[];
-}
-
-async function fixFile(
-  scanResult: ScanFileResult,
-  cache: Record<string, Codemod>
-): Promise<void> {
-  let newContent = scanResult.contents;
-
-  for (const replacement of scanResult.matches) {
-    const factory = codemods[replacement.moduleName];
-
-    if (!factory) {
-      continue;
-    }
-
-    const cachedInstance = cache[replacement.moduleName];
-    let codemod;
-    if (!cachedInstance) {
-      codemod = factory({});
-      cache[replacement.moduleName] = codemod;
-    } else {
-      codemod = cachedInstance;
-    }
-
-    try {
-      const transformResult = await codemod.transform({
-        file: {
-          filename: scanResult.path,
-          source: newContent
-        }
-      });
-
-      cl.log.success(dedent`
-        Applying codemod ${pc.cyan(replacement.moduleName)} to ${scanResult.path}
-      `);
-
-      newContent = transformResult;
-    } catch (err) {
-      cl.log.error(dedent`
-        ${pc.bold('Error:')} the ${pc.cyan(replacement.moduleName)} codemod unexpectedly threw an exception:
-
-        ${err}
-      `);
-    }
-  }
-
-  if (scanResult.contents !== newContent) {
-    await writeFile(scanResult.path, newContent, 'utf8');
-  }
-}
-
-async function fixFiles(scanResults: ScanFileResult[]): Promise<void> {
-  const codemodCache: Record<string, Codemod> = {};
-
-  for (const result of scanResults) {
-    await fixFile(result, codemodCache);
-  }
-}
-
-async function scanFile(
-  filePath: string,
-  contents: string,
-  lines: string[],
-  replacements: modReplacements.ModuleReplacement[]
-): Promise<ScanFileResult> {
-  const ast = sg.parse(contents);
-  const root = ast.root();
-  const result: ScanFileResult = {
-    path: filePath,
-    contents,
-    matches: []
-  };
-
-  for (const replacement of replacements) {
-    const imports = root.findAll({
-      rule: {
-        any: [
-          {
-            pattern: {
-              context: `import $NAME from '${replacement.moduleName}'`,
-              strictness: 'relaxed'
-            }
-          },
-          {
-            pattern: {
-              context: `require('${replacement.moduleName}')`,
-              strictness: 'relaxed'
-            }
-          }
-        ]
-      }
-    });
-
-    if (imports.length > 0) {
-      result.matches.push(replacement);
-    }
-
-    for (const node of imports) {
-      const range = node.range();
-      let snippet: string = '';
-
-      const prevLine = lines[range.start.line - 1];
-      const line = lines[range.start.line];
-      const nextLine = lines[range.start.line + 1];
-
-      if (prevLine) {
-        snippet += `${range.start.line} | ${prevLine}\n`;
-      }
-
-      snippet += `${range.start.line + 1} | ${pc.red(line)}\n`;
-
-      if (nextLine) {
-        snippet += `${range.start.line + 2} | ${nextLine}\n`;
-      }
-
-      suggestReplacement(replacement, {
-        type: 'file',
-        path: filePath,
-        line: range.start.line,
-        column: range.start.column,
-        snippet
-      });
-    }
-  }
-
-  return result;
-}
-
-const knownFileExtensions = new Set<string>(['.tsx', '.ts', '.js', '.jsx']);
-
-async function scanFiles(
-  files: string[],
-  replacements: modReplacements.ModuleReplacement[],
-  spinner: ReturnType<typeof cl.spinner>
-): Promise<ScanFileResult[]> {
-  const results: ScanFileResult[] = [];
-
-  for (const file of files) {
-    try {
-      const contents = await readFile(file, 'utf8');
-      const lines = contents.split('\n');
-
-      spinner.message(`Scanning ${file}`);
-
-      results.push(await scanFile(file, contents, lines, replacements));
-    } catch (err) {
-      cl.log.error(dedent`
-        Could not read file ${file}:
-
-        ${String(err)}
-      `);
-    }
-  }
-
-  return results;
-}
-
-async function traverseFiles(dirPath: string): Promise<string[]> {
-  const fileScanner = new fdir();
-
-  fileScanner
-    .withFullPaths()
-    .exclude((dirName) => dirName === 'node_modules')
-    .filter((filePath, isDir) => {
-      return !isDir && knownFileExtensions.has(extname(filePath));
-    });
-
-  return await fileScanner.crawl(dirPath).withPromise();
-}
 
 function isDependenciesLike(obj: unknown): obj is Record<string, string> {
   if (typeof obj !== 'object' || obj === null) {
@@ -328,189 +27,188 @@ function isDependenciesLike(obj: unknown): obj is Record<string, string> {
   return true;
 }
 
-cl.intro('mr-cli');
+export async function run(): Promise<void> {
+  const cwd = getCwd();
+  const packageManifest = await findPackage(cwd);
 
-if (packageManifest === null) {
-  cl.log.error(dedent`
-    Could not find package.json. Please ensure that you run this command in a project which has one setup.
+  cl.intro('mr-cli');
+
+  if (packageManifest === null) {
+    cl.log.error(dedent`
+      Could not find package.json. Please ensure that you run this command in a project which has one setup.
+    `);
+    cl.cancel();
+    exit(0);
+  }
+
+  cl.log.message(dedent`
+    We will search your project for modules which can be replaced by faster or lighter alternatives.
+
+    Before we do that, we need to determine what level of strictness you want to apply.
   `);
-  cl.cancel();
-  exit(0);
-}
 
-/**
- * TODO:
- *
- * - Lint `package.json` for module replacements
- * - Allow user to choose which manifests to apply (via strictness?)
- * - Offer to autofix ones with codemods
- */
+  const options = await cl.group(
+    {
+      manifests: () =>
+        cl.multiselect({
+          message: 'Choose which module lists to apply',
+          initialValues: ['native', 'micro-utilities', 'preferred'],
+          required: true,
+          options: [
+            {
+              label: 'native',
+              value: 'native',
+              hint: 'modules with native replacements'
+            },
+            {
+              label: 'micro utilities',
+              hint: 'more opinionated list of modules which can be replaced with native code',
+              value: 'micro-utilities'
+            },
+            {
+              label: 'preferred',
+              hint: 'opinionated list of faster and leaner packages',
+              value: 'preferred'
+            }
+          ]
+        }),
+      includeDevDependencies: () =>
+        cl.confirm({
+          message: 'Include devDependencies?',
+          initialValue: false
+        }),
+      filesDir: () =>
+        cl.text({
+          message: `Which directory would you like to scan for files? (default: ${cwd})`,
+          defaultValue: cwd
+        }),
+      fix: () =>
+        cl.confirm({
+          message: 'Automatically apply codemods?',
+          initialValue: false
+        }),
+      autoUninstall: () =>
+        cl.confirm({
+          message: 'Automatically uninstall packages?',
+          initialValue: false
+        })
+    },
+    {
+      onCancel: () => {
+        cl.cancel('Operation was cancelled.');
+        exit(0);
+      }
+    }
+  );
 
-cl.log.message(dedent`
-  We will search your project for modules which can be replaced by faster or lighter alternatives.
+  const packageDependencies = packageManifest.dependencies;
+  const packageDevDependencies = packageManifest.devDependencies;
 
-  Before we do that, we need to determine what level of strictness you want to apply.
-`);
+  const manifestReplacements: modReplacements.ModuleReplacement[] = [];
 
-const options = await cl.group(
-  {
-    manifests: () =>
-      cl.multiselect({
-        message: 'Choose which module lists to apply',
-        initialValues: ['native', 'micro-utilities', 'preferred'],
-        required: true,
-        options: [
-          {
-            label: 'native',
-            value: 'native',
-            hint: 'modules with native replacements'
-          },
-          {
-            label: 'micro utilities',
-            hint: 'more opinionated list of modules which can be replaced with native code',
-            value: 'micro-utilities'
-          },
-          {
-            label: 'preferred',
-            hint: 'opinionated list of faster and leaner packages',
-            value: 'preferred'
-          }
-        ]
-      }),
-    includeDevDependencies: () =>
-      cl.confirm({
-        message: 'Include devDependencies?',
-        initialValue: false
-      }),
-    filesDir: () =>
-      cl.text({
-        message: `Which directory would you like to scan for files? (default: ${cwd()})`,
-        defaultValue: cwd()
-      }),
-    fix: () =>
-      cl.confirm({
-        message: 'Automatically apply codemods?',
-        initialValue: false
-      }),
-    autoUninstall: () =>
-      cl.confirm({
-        message: 'Automatically uninstall packages?',
-        initialValue: false
-      })
-  },
-  {
-    onCancel: () => {
-      cl.cancel('Operation was cancelled.');
-      exit(0);
+  for (const manifestName of options.manifests) {
+    const manifestModule = availableManifests[manifestName];
+
+    if (manifestModule) {
+      for (const replacement of manifestModule.moduleReplacements) {
+        manifestReplacements.push(replacement);
+      }
     }
   }
-);
 
-const packageDependencies = packageManifest.dependencies;
-const packageDevDependencies = packageManifest.devDependencies;
+  const packageScanSpinner = cl.spinner();
 
-const manifestReplacements: modReplacements.ModuleReplacement[] = [];
+  packageScanSpinner.start('Scanning `package.json` dependencies');
 
-for (const manifestName of options.manifests) {
-  const manifestModule = availableManifests[manifestName];
+  const dependenciesToRemove: string[] = [];
+  const devDependenciesToRemove: string[] = [];
+  let packageJsonFailed = false;
 
-  if (manifestModule) {
-    for (const replacement of manifestModule.moduleReplacements) {
-      manifestReplacements.push(replacement);
+  if (isDependenciesLike(packageDependencies)) {
+    const traverseResults = scanDependencies(
+      packageDependencies,
+      manifestReplacements,
+      'dependencies'
+    );
+
+    if (options.autoUninstall) {
+      for (const result of traverseResults) {
+        dependenciesToRemove.push(result.replacement.moduleName);
+      }
     }
+
+    packageJsonFailed = true;
   }
-}
 
-const packageScanSpinner = cl.spinner();
+  if (
+    options.includeDevDependencies &&
+    isDependenciesLike(packageDevDependencies)
+  ) {
+    const traverseResults = scanDependencies(
+      packageDevDependencies,
+      manifestReplacements,
+      'devDependencies'
+    );
 
-packageScanSpinner.start('Scanning `package.json` dependencies');
+    if (options.autoUninstall) {
+      for (const result of traverseResults) {
+        devDependenciesToRemove.push(result.replacement.moduleName);
+      }
+    }
 
-const dependenciesToRemove: string[] = [];
-const devDependenciesToRemove: string[] = [];
-let packageJsonFailed = false;
+    packageJsonFailed = true;
+  }
 
-if (isDependenciesLike(packageDependencies)) {
-  const traverseResults = traverseDependencies(
-    packageDependencies,
+  if (packageJsonFailed) {
+    packageScanSpinner.stop(
+      '`package.json` dependencies scanned successfully.'
+    );
+  } else {
+    packageScanSpinner.stop(
+      '`package.json` contained replaceable dependencies.',
+      2
+    );
+  }
+
+  if (
+    options.autoUninstall &&
+    (dependenciesToRemove.length > 0 || devDependenciesToRemove.length > 0)
+  ) {
+    const npmSpinner = cl.spinner();
+
+    npmSpinner.start('Removing npm dependencies');
+
+    if (dependenciesToRemove.length > 0) {
+      await x('npm', ['rm', '-S', ...dependenciesToRemove]);
+    }
+    if (devDependenciesToRemove.length > 0) {
+      await x('npm', ['rm', '-D', ...devDependenciesToRemove]);
+    }
+
+    npmSpinner.stop('npm dependencies removed');
+  }
+
+  const fileScanSpinner = cl.spinner();
+
+  fileScanSpinner.start('Scanning files');
+
+  const files = await traverseFiles(options.filesDir);
+
+  const scanFilesResult = await scanFiles(
+    files,
     manifestReplacements,
-    'dependencies'
+    fileScanSpinner
   );
 
-  if (options.autoUninstall) {
-    for (const result of traverseResults) {
-      dependenciesToRemove.push(result.match.moduleName);
-    }
+  if (scanFilesResult.length > 0) {
+    fileScanSpinner.stop('Detected files with replaceable modules!', 2);
+  } else {
+    fileScanSpinner.stop('All files scanned');
   }
 
-  packageJsonFailed = true;
-}
-
-if (
-  options.includeDevDependencies &&
-  isDependenciesLike(packageDevDependencies)
-) {
-  const traverseResults = traverseDependencies(
-    packageDevDependencies,
-    manifestReplacements,
-    'devDependencies'
-  );
-
-  if (options.autoUninstall) {
-    for (const result of traverseResults) {
-      devDependenciesToRemove.push(result.match.moduleName);
-    }
+  if (options.fix) {
+    await fixFiles(scanFilesResult);
   }
 
-  packageJsonFailed = true;
+  cl.outro('All checks complete!');
 }
-
-if (packageJsonFailed) {
-  packageScanSpinner.stop('`package.json` dependencies scanned successfully.');
-} else {
-  packageScanSpinner.stop(
-    '`package.json` contained replaceable dependencies.',
-    2
-  );
-}
-
-if (
-  options.autoUninstall &&
-  (dependenciesToRemove.length > 0 || devDependenciesToRemove.length > 0)
-) {
-  const npmSpinner = cl.spinner();
-
-  npmSpinner.start('Removing npm dependencies');
-
-  if (dependenciesToRemove.length > 0) {
-    await x('npm', ['rm', '-S', ...dependenciesToRemove]);
-  }
-  if (devDependenciesToRemove.length > 0) {
-    await x('npm', ['rm', '-D', ...devDependenciesToRemove]);
-  }
-
-  npmSpinner.stop('npm dependencies removed');
-}
-
-const fileScanSpinner = cl.spinner();
-
-fileScanSpinner.start('Scanning files');
-
-const files = await traverseFiles(options.filesDir);
-
-const scanFilesResult = await scanFiles(
-  files,
-  manifestReplacements,
-  fileScanSpinner
-);
-
-if (scanFilesResult.length > 0) {
-  fileScanSpinner.stop('Detected files with replaceable modules!', 2);
-} else {
-  fileScanSpinner.stop('All files scanned');
-}
-
-if (options.fix) {
-  await fixFiles(scanFilesResult);
-}
-
-cl.outro('All checks complete!');

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -1,0 +1,28 @@
+import * as modReplacements from 'module-replacements';
+
+export interface FileReplacement {
+  path: string;
+  contents: string;
+  replacements: modReplacements.ModuleReplacement[];
+}
+
+export interface DependencyReplacement {
+  replacement: modReplacements.ModuleReplacement;
+  source: 'dependencies' | 'devDependencies';
+  name: string;
+}
+
+export interface PackageSource {
+  type: 'package';
+  source: 'dependencies' | 'devDependencies';
+}
+
+export interface FileSource {
+  type: 'file';
+  path: string;
+  line: number;
+  column: number;
+  snippet: string;
+}
+
+export type Source = PackageSource | FileSource;

--- a/src/stages/fix-files.ts
+++ b/src/stages/fix-files.ts
@@ -1,0 +1,63 @@
+import pc from 'picocolors';
+import {writeFile} from 'node:fs/promises';
+import {codemods, type Codemod} from 'module-replacements-codemods';
+import dedent from 'dedent';
+import * as cl from '@clack/prompts';
+import {type FileReplacement} from '../shared-types.js';
+
+async function fixFile(
+  scanResult: FileReplacement,
+  cache: Record<string, Codemod>
+): Promise<void> {
+  let newContent = scanResult.contents;
+
+  for (const replacement of scanResult.replacements) {
+    const factory = codemods[replacement.moduleName];
+
+    if (!factory) {
+      continue;
+    }
+
+    const cachedInstance = cache[replacement.moduleName];
+    let codemod;
+    if (!cachedInstance) {
+      codemod = factory({});
+      cache[replacement.moduleName] = codemod;
+    } else {
+      codemod = cachedInstance;
+    }
+
+    try {
+      const transformResult = await codemod.transform({
+        file: {
+          filename: scanResult.path,
+          source: newContent
+        }
+      });
+
+      cl.log.success(dedent`
+        Applying codemod ${pc.cyan(replacement.moduleName)} to ${scanResult.path}
+      `);
+
+      newContent = transformResult;
+    } catch (err) {
+      cl.log.error(dedent`
+        ${pc.bold('Error:')} the ${pc.cyan(replacement.moduleName)} codemod unexpectedly threw an exception:
+
+        ${err}
+      `);
+    }
+  }
+
+  if (scanResult.contents !== newContent) {
+    await writeFile(scanResult.path, newContent, 'utf8');
+  }
+}
+
+export async function fixFiles(scanResults: FileReplacement[]): Promise<void> {
+  const codemodCache: Record<string, Codemod> = {};
+
+  for (const result of scanResults) {
+    await fixFile(result, codemodCache);
+  }
+}

--- a/src/stages/scan-dependencies.ts
+++ b/src/stages/scan-dependencies.ts
@@ -1,0 +1,26 @@
+import * as modReplacements from 'module-replacements';
+import {type DependencyReplacement} from '../shared-types.js';
+import {suggestReplacement} from '../suggest-replacement.js';
+
+export function scanDependencies(
+  dependencies: Record<string, string>,
+  replacements: modReplacements.ModuleReplacement[],
+  source: 'dependencies' | 'devDependencies'
+): DependencyReplacement[] {
+  const results: DependencyReplacement[] = [];
+
+  for (const key in dependencies) {
+    for (const replacement of replacements) {
+      if (key === replacement.moduleName) {
+        results.push({
+          replacement,
+          name: replacement.moduleName,
+          source
+        });
+        suggestReplacement(replacement, {type: 'package', source});
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/stages/scan-files.ts
+++ b/src/stages/scan-files.ts
@@ -1,0 +1,104 @@
+import * as modReplacements from 'module-replacements';
+import {ts as sg} from '@ast-grep/napi';
+import {readFile} from 'node:fs/promises';
+import dedent from 'dedent';
+import pc from 'picocolors';
+import * as cl from '@clack/prompts';
+import {type FileReplacement} from '../shared-types.js';
+import {suggestReplacement} from '../suggest-replacement.js';
+
+async function scanFile(
+  filePath: string,
+  contents: string,
+  lines: string[],
+  replacements: modReplacements.ModuleReplacement[]
+): Promise<FileReplacement> {
+  const ast = sg.parse(contents);
+  const root = ast.root();
+  const result: FileReplacement = {
+    path: filePath,
+    contents,
+    replacements: []
+  };
+
+  for (const replacement of replacements) {
+    const imports = root.findAll({
+      rule: {
+        any: [
+          {
+            pattern: {
+              context: `import $NAME from '${replacement.moduleName}'`,
+              strictness: 'relaxed'
+            }
+          },
+          {
+            pattern: {
+              context: `require('${replacement.moduleName}')`,
+              strictness: 'relaxed'
+            }
+          }
+        ]
+      }
+    });
+
+    if (imports.length > 0) {
+      result.replacements.push(replacement);
+    }
+
+    for (const node of imports) {
+      const range = node.range();
+      let snippet: string = '';
+
+      const prevLine = lines[range.start.line - 1];
+      const line = lines[range.start.line];
+      const nextLine = lines[range.start.line + 1];
+
+      if (prevLine) {
+        snippet += `${range.start.line} | ${prevLine}\n`;
+      }
+
+      snippet += `${range.start.line + 1} | ${pc.red(line)}\n`;
+
+      if (nextLine) {
+        snippet += `${range.start.line + 2} | ${nextLine}\n`;
+      }
+
+      suggestReplacement(replacement, {
+        type: 'file',
+        path: filePath,
+        line: range.start.line,
+        column: range.start.column,
+        snippet
+      });
+    }
+  }
+
+  return result;
+}
+
+export async function scanFiles(
+  files: string[],
+  replacements: modReplacements.ModuleReplacement[],
+  spinner: ReturnType<typeof cl.spinner>
+): Promise<FileReplacement[]> {
+  const results: FileReplacement[] = [];
+
+  for (const file of files) {
+    try {
+      const contents = await readFile(file, 'utf8');
+      const lines = contents.split('\n');
+
+      spinner.message(`Scanning ${file}`);
+
+      results.push(await scanFile(file, contents, lines, replacements));
+    } catch (err) {
+      cl.log.error(dedent`
+        Could not read file ${file}:
+
+        ${String(err)}
+      `);
+    }
+  }
+
+  return results;
+}

--- a/src/stages/traverse-files.ts
+++ b/src/stages/traverse-files.ts
@@ -1,0 +1,17 @@
+import {fdir} from 'fdir';
+import {extname} from 'node:path';
+
+const knownFileExtensions = new Set<string>(['.tsx', '.ts', '.js', '.jsx']);
+
+export async function traverseFiles(dirPath: string): Promise<string[]> {
+  const fileScanner = new fdir();
+
+  fileScanner
+    .withFullPaths()
+    .exclude((dirName) => dirName === 'node_modules')
+    .filter((filePath, isDir) => {
+      return !isDir && knownFileExtensions.has(extname(filePath));
+    });
+
+  return await fileScanner.crawl(dirPath).withPromise();
+}

--- a/src/suggest-replacement.ts
+++ b/src/suggest-replacement.ts
@@ -1,0 +1,88 @@
+import * as modReplacements from 'module-replacements';
+import pc from 'picocolors';
+import dedent from 'dedent';
+import * as cl from '@clack/prompts';
+import {getDocsUrl, getMdnUrl} from './replacement-urls.js';
+import {type Source} from './shared-types.js';
+
+function renderSource(source: Source): string {
+  switch (source.type) {
+    case 'package':
+      return dedent`
+        ${pc.bold('package.json')}
+      `;
+    case 'file':
+      return dedent`
+        ${pc.bold(`${source.path} (${source.line}:${source.column})`)}
+
+        ${source.snippet}
+      `;
+  }
+}
+
+function suggestDocumentedReplacement(
+  replacement: modReplacements.DocumentedModuleReplacement,
+  source: Source
+): void {
+  cl.log.warn(dedent`
+    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
+
+    Module ${pc.cyan(replacement.moduleName)} could be replaced with a more performant alternative.
+
+    You can find an alternative in the following documentation:
+    ${pc.underline(getDocsUrl(replacement.docPath))}
+  `);
+}
+
+function suggestNativeReplacement(
+  replacement: modReplacements.NativeModuleReplacement,
+  source: Source
+): void {
+  cl.log.warn(dedent`
+    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
+
+    Module ${pc.cyan(replacement.moduleName)} could be replaced with the following native functionality:
+
+    ${pc.underline(getMdnUrl(replacement.mdnPath))}
+  `);
+}
+
+function suggestNoneReplacement(
+  replacement: modReplacements.NoModuleReplacement,
+  source: Source
+): void {
+  cl.log.warn(dedent`
+    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
+
+    Module ${pc.cyan(replacement.moduleName)} could be removed or replaced with a more performant alternative.
+  `);
+}
+
+function suggestSimpleReplacement(
+  replacement: modReplacements.SimpleModuleReplacement,
+  source: Source
+): void {
+  cl.log.warn(dedent`
+    ${pc.bold(replacement.moduleName)} - ${renderSource(source)}
+
+    Module ${pc.cyan(replacement.moduleName)} could be replaced inline/native equivalent logic.
+
+    ${replacement.replacement}
+  `);
+}
+
+export function suggestReplacement(
+  replacement: modReplacements.ModuleReplacement,
+  source: Source
+): void {
+  switch (replacement.type) {
+    case 'documented':
+      return suggestDocumentedReplacement(replacement, source);
+    case 'native':
+      return suggestNativeReplacement(replacement, source);
+    case 'none':
+      return suggestNoneReplacement(replacement, source);
+    case 'simple':
+      return suggestSimpleReplacement(replacement, source);
+  }
+}


### PR DESCRIPTION
Moves the various stages into their own modules and simplifies the main entrypoint because of that.

Also adds a `bin` to the `package.json`.